### PR TITLE
fix(llama): distinguish zephyr/tinyllama from phi chat template

### DIFF
--- a/families/llama/runtime/chat_templates.cpp
+++ b/families/llama/runtime/chat_templates.cpp
@@ -25,6 +25,11 @@ std::string apply_phi(const std::string& prompt, bool /*enable_thinking*/) {
     return "<|user|>\n" + prompt + "<|end|>\n<|assistant|>\n";
 }
 
+// Zephyr / TinyLlama share role tags with Phi but end turns with eos (</s>), not <|end|>.
+std::string apply_zephyr(const std::string& prompt, bool /*enable_thinking*/) {
+    return "<|user|>\n" + prompt + "</s>\n<|assistant|>\n";
+}
+
 std::string apply_gemma(const std::string& prompt, bool /*enable_thinking*/) {
     return "<start_of_turn>user\n" + prompt + "<end_of_turn>\n<start_of_turn>model\n";
 }
@@ -58,9 +63,14 @@ std::string llama_detect_chat_template_format(const std::string& jinja_template)
         return "chatml";
     if (jinja_template.find("[INST]") != std::string::npos)
         return "mistral";
+    // Phi and Zephyr/TinyLlama both use <|user|>/<|assistant|>. Phi is distinguished by
+    // literal <|end|> turn separators; Zephyr/TinyLlama concatenate eos_token (</s>) instead.
     if (jinja_template.find("<|user|>") != std::string::npos ||
-        jinja_template.find("<|assistant|>") != std::string::npos)
-        return "phi";
+        jinja_template.find("<|assistant|>") != std::string::npos) {
+        if (jinja_template.find("<|end|>") != std::string::npos)
+            return "phi";
+        return "zephyr";
+    }
     if (jinja_template.find("<start_of_turn>") != std::string::npos)
         return "gemma";
     if (jinja_template.find("<|start_header_id|>") != std::string::npos)
@@ -82,6 +92,8 @@ std::string llama_apply_chat_template(const std::string& format, const std::stri
         return apply_mistral(prompt, enable_thinking);
     if (format == "phi")
         return apply_phi(prompt, enable_thinking);
+    if (format == "zephyr")
+        return apply_zephyr(prompt, enable_thinking);
     if (format == "gemma")
         return apply_gemma(prompt, enable_thinking);
     if (format == "llama3")

--- a/families/llama/tests/cpp/test_llama_chat_template.cpp
+++ b/families/llama/tests/cpp/test_llama_chat_template.cpp
@@ -48,6 +48,27 @@ static void test_detect_phi() {
     check(fmt == "phi", "phi detection");
 }
 
+// TinyLlama-1.1B-Chat / Zephyr: same role tags as Phi, but turns end with eos_token (</s>),
+// not Phi's literal <|end|>. Must not be classified as phi (issue #1271).
+static void test_detect_zephyr_tinyllama() {
+    std::string tpl =
+        "{% for message in messages %}\n"
+        "{% if message['role'] == 'user' %}\n"
+        "{{ '<|user|>\n' + message['content'] + eos_token }}\n"
+        "{% elif message['role'] == 'system' %}\n"
+        "{{ '<|system|>\n' + message['content'] + eos_token }}\n"
+        "{% elif message['role'] == 'assistant' %}\n"
+        "{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n"
+        "{% endif %}\n"
+        "{% if loop.last and add_generation_prompt %}\n"
+        "{{ '<|assistant|>' }}\n"
+        "{% endif %}\n"
+        "{% endfor %}";
+    auto fmt = trtmc::llama_detect_chat_template_format(tpl);
+    check(fmt == "zephyr", "zephyr/tinyllama detection");
+    check(fmt != "phi", "zephyr/tinyllama must not be phi");
+}
+
 static void test_detect_gemma() {
     std::string tpl = "{% for message in messages %}<start_of_turn>{{ message.role }}\n{{ "
                       "message.content }}<end_of_turn>\n{% endfor %}";
@@ -86,6 +107,18 @@ static void test_apply_phi() {
     check(result == "<|user|>\nhello<|end|>\n<|assistant|>\n", "phi application");
 }
 
+static void test_apply_zephyr_tinyllama() {
+    auto result = trtmc::llama_apply_chat_template("zephyr", "hello");
+    check(result == "<|user|>\nhello</s>\n<|assistant|>\n", "zephyr/tinyllama application");
+    // Issue #1271 e2e prompt: must use </s>, not Phi <|end|>.
+    auto e2e = trtmc::llama_apply_chat_template(
+        "zephyr", "What is the capital of France? Answer in one word.");
+    check(e2e == "<|user|>\nWhat is the capital of France? Answer in one word.</s>\n"
+                 "<|assistant|>\n",
+          "zephyr/tinyllama e2e prompt render");
+    check(e2e.find("<|end|>") == std::string::npos, "zephyr render must not inject <|end|>");
+}
+
 static void test_apply_gemma() {
     auto result = trtmc::llama_apply_chat_template("gemma", "hello");
     check(result == "<start_of_turn>user\nhello<end_of_turn>\n<start_of_turn>model\n",
@@ -104,12 +137,14 @@ int main() {
     test_detect_chatml();
     test_detect_mistral();
     test_detect_phi();
+    test_detect_zephyr_tinyllama();
     test_detect_gemma();
     test_detect_llama3();
     test_detect_nemotron_h();
     test_apply_chatml_no_thinking();
     test_apply_mistral_no_thinking_ignored();
     test_apply_phi();
+    test_apply_zephyr_tinyllama();
     test_apply_gemma();
     test_apply_llama3();
     test_apply_nemotron_h_no_thinking();

--- a/families/llama/tests/cpp/test_llama_chat_template.cpp
+++ b/families/llama/tests/cpp/test_llama_chat_template.cpp
@@ -51,19 +51,18 @@ static void test_detect_phi() {
 // TinyLlama-1.1B-Chat / Zephyr: same role tags as Phi, but turns end with eos_token (</s>),
 // not Phi's literal <|end|>. Must not be classified as phi (issue #1271).
 static void test_detect_zephyr_tinyllama() {
-    std::string tpl =
-        "{% for message in messages %}\n"
-        "{% if message['role'] == 'user' %}\n"
-        "{{ '<|user|>\n' + message['content'] + eos_token }}\n"
-        "{% elif message['role'] == 'system' %}\n"
-        "{{ '<|system|>\n' + message['content'] + eos_token }}\n"
-        "{% elif message['role'] == 'assistant' %}\n"
-        "{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n"
-        "{% endif %}\n"
-        "{% if loop.last and add_generation_prompt %}\n"
-        "{{ '<|assistant|>' }}\n"
-        "{% endif %}\n"
-        "{% endfor %}";
+    std::string tpl = "{% for message in messages %}\n"
+                      "{% if message['role'] == 'user' %}\n"
+                      "{{ '<|user|>\n' + message['content'] + eos_token }}\n"
+                      "{% elif message['role'] == 'system' %}\n"
+                      "{{ '<|system|>\n' + message['content'] + eos_token }}\n"
+                      "{% elif message['role'] == 'assistant' %}\n"
+                      "{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n"
+                      "{% endif %}\n"
+                      "{% if loop.last and add_generation_prompt %}\n"
+                      "{{ '<|assistant|>' }}\n"
+                      "{% endif %}\n"
+                      "{% endfor %}";
     auto fmt = trtmc::llama_detect_chat_template_format(tpl);
     check(fmt == "zephyr", "zephyr/tinyllama detection");
     check(fmt != "phi", "zephyr/tinyllama must not be phi");


### PR DESCRIPTION
## Background

Fixes #1271.

`families/llama/tests/manifests/tinyllama-1.1b.json` e2e fails because the native
runtime's first decode step predicts EOS immediately (`token_ids: [2]`, empty
text). HF reference greedy generation for the same prompt and chat template
returns a real answer (`token_ids: [12415, 2410, 29901, 3681, 2]`, text
`Capital: Paris`).

root cause (confirmed via template + detection/render comparison, not GPU
logits): `llama_detect_chat_template_format` treated any jinja containing
`<|user|>` / `<|assistant|>` as **phi**. TinyLlama-1.1B-Chat (and Zephyr) use
those role tags but end turns with `eos_token` (`</s>`), not Phi's literal
`<|end|>`. `apply_phi()` therefore injected `<|end|>` separators the model was
never trained on, which matches the observed out-of-distribution first-step EOS.

unrelated to open PR #1269 (eos_token_id list); that work does not touch
chat-template detection/rendering.

## Exit Criteria

- TinyLlama / Zephyr jinja (role tags + `eos_token`, no `<|end|>`) detects as
  `zephyr`, not `phi`.
- Phi jinja (role tags + `<|end|>`) still detects as `phi`.
- `llama_apply_chat_template("zephyr", ...)` renders
  `<|user|>\n{prompt}</s>\n<|assistant|>\n` (matches HF `apply_chat_template`
  with `trim_blocks`/`lstrip_blocks`).
- non-goal: does not change eos_token_id list handling (#1269).
- non-goal of this PR alone: full A40 GPU e2e (no local NVIDIA GPU here); ask
  maintainers/CI GPU to confirm the e2e harness.

## Implementation

in `families/llama/runtime/chat_templates.cpp`:

- require `<|end|>` (in addition to role tags) to classify **phi**.
- otherwise classify role-tag templates without `<|end|>` as **zephyr**.
- add `apply_zephyr()` that uses `</s>` turn ends instead of `<|end|>`.

regression coverage in `families/llama/tests/cpp/test_llama_chat_template.cpp`
(detect + apply + e2e prompt string; asserts no `<|end|>` in zephyr render).

affected: llama family chat-template detection/apply only. no public API, ABI,
or bundle format change (format string is internal; bundles still store the
same `chat_template.jinja` section).

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

```
g++ -std=c++17 -Wall -Wextra -Wpedantic -I. \
  -o /tmp/test_llama_chat_template \
  families/llama/tests/cpp/test_llama_chat_template.cpp \
  families/llama/runtime/chat_templates.cpp
/tmp/test_llama_chat_template
# All llama chat_template tests passed.
```

also verified detect/apply on the real TinyLlama and Phi-3 jinja strings:

- TinyLlama tokenizer_config chat_template -> `zephyr`
- Phi-3 (`<|end|>` present) -> `phi`
- zephyr apply for the issue prompt:
  `<|user|>\nWhat is the capital of France? Answer in one word.</s>\n<|assistant|>\n`
- phi apply (broken path TinyLlama was hitting):
  `<|user|>\nWhat is the capital of France? Answer in one word.<|end|>\n<|assistant|>\n`

HF-equivalent jinja render (jinja2 `trim_blocks=True`, `lstrip_blocks=True`,
same as transformers) matches the zephyr apply string above.

### Hardware, Environment, and Revisions

- tested head: this branch (`fix/tinyllama-chat-template-format`)
- CPU-only box; **no NVIDIA GPU / no nvidia-smi**; cannot run A40 e2e or
  `trtmc run` / `pytest families/llama/tests/test_e2e.py --e2e-model=tinyllama-1.1b`
- TinyLlama template taken from `TinyLlama/TinyLlama-1.1B-Chat-v1.0` tokenizer_config
  on HF `main`; Phi comparison from `microsoft/Phi-3-mini-4k-instruct`

### Not Run / Remaining Gaps

- full GPU e2e for `tinyllama-1.1b` (build bundle + native vs HF reference) was
  **not** run locally. please confirm on community GPU CI / a machine with CUDA
  that `pytest families/llama/tests/test_e2e.py --e2e-model=tinyllama-1.1b`
  now produces non-empty text aligned with the HF reference cited in #1271.
- other llama e2e manifests not re-run (chat-template path for phi-tagged models
  unchanged aside from requiring `<|end|>` for phi classification).

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

- suggested review order: detection change in `chat_templates.cpp`, then
  `apply_zephyr`, then new unit tests.
- if a future model uses `<|user|>` with a non-`</s>` eos, detection may need a
  richer signal; TinyLlama/Zephyr eos is `</s>` and matches this apply path.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: surgical heuristic tightening plus one new format path; phi
behavior preserved when `<|end|>` is present; covered by non-GPU unit tests.